### PR TITLE
Fix notice when deleting last record

### DIFF
--- a/Model/Behavior/AggregateCacheBehavior.php
+++ b/Model/Behavior/AggregateCacheBehavior.php
@@ -83,8 +83,12 @@ class AggregateCacheBehavior extends ModelBehavior {
             foreach ($aggregate as $function => $cacheField) { 
                 if (!in_array($function, $this->functions)) { 
                     continue; 
-                } 
-                $newValues[$cacheField] = $results[0][$function . '_value']; 
+                }
+                if (empty($results)) {
+                    $newValues[$cacheField] = 0;
+                } else {
+                    $newValues[$cacheField] = $results[0][$function . '_value'];
+                }
             } 
             $assocModel->id = $foreignId; 
             $assocModel->save($newValues, false, array_keys($newValues)); 


### PR DESCRIPTION
When deleting the last record for a given foreign key, the $results (sum in my example) would be completely empty as there were no records to sum.
