### PR TITLE
allow multiple aggredated fields

### DIFF
--- a/Model/Behavior/AggregateCacheBehavior.php
+++ b/Model/Behavior/AggregateCacheBehavior.php
@@ -50,7 +50,7 @@ class AggregateCacheBehavior extends ModelBehavior {
                 $aggregate['field'] = $k; 
             } 
             if (!empty($aggregate['field']) && !empty($aggregate['model'])) { 
-                $this->config[] = $aggregate; 
+                $this->config[$model->alias][] = $aggregate; 
             } 
         } 
     } 
@@ -100,7 +100,7 @@ class AggregateCacheBehavior extends ModelBehavior {
         if(array_diff_key($model->schema(),$model->data[$model->alias]) !== []):
             $model->read();
         endif;
-        foreach ($this->config as $aggregate) { 
+        foreach ($this->config[$model->alias] as $aggregate) { 
             if (!array_key_exists($aggregate['model'], $model->belongsTo)) { 
                 continue; 
             } 
@@ -118,7 +118,7 @@ class AggregateCacheBehavior extends ModelBehavior {
     } 
 
     public function afterDelete(Model $model) { 
-        foreach ($this->config as $aggregate) { 
+        foreach ($this->config[$model->alias] as $aggregate) { 
             if (!array_key_exists($aggregate['model'], $model->belongsTo)) { 
                 continue; 
             } 


### PR DESCRIPTION
Fixes an issue where there are multiple aggregated fields from different relations. Otherwise it will try to run the aggregation for different relations on the trigering relation.

Example:

class ReceiptLine extends AppModel {  
    public $actsAs = array('AggregateCache.AggregateCache'=>array(array(
            'field'=>'amount',
            'model'=>'Receipt',
            'sum'=>'total',
            'recursive'=>-1
    )));
    public $belongsTo = array('Receipt');
}

class Payment extends AppModel {
    public $actsAs = array('AggregateCache.AggregateCache'=>array(array(
            'field'=>'amount',
            'model'=>'Receipt',
            'sum'=>'amount_paid'
    )));
    public $belongsTo = array('Receipt');
}
