### PR TITLE
Handle foreignId changes, updateCache on both old and new

### DIFF
--- a/Model/Behavior/AggregateCacheBehavior.php
+++ b/Model/Behavior/AggregateCacheBehavior.php
@@ -92,7 +92,15 @@ class AggregateCacheBehavior extends ModelBehavior {
             $assocModel->id = $foreignId; 
             $assocModel->save($newValues, false, array_keys($newValues)); 
         } 
-    } 
+    }
+    
+    public function beforeSave(Model $model, $options = array()) {
+        # Get the current foreignId in case it is different afterSave
+        foreach ($model->belongsTo as $assocKey => $assocData) { 
+            $this->foreignTableIDs[$assocData['className']] = $model->field($assocData['foreignKey']); 
+        }         
+        return true;
+    }    
 
     public function afterSave(Model $model, $created, $options = []) {
         # broad check to make sure $model->data has all the fields
@@ -107,6 +115,10 @@ class AggregateCacheBehavior extends ModelBehavior {
             $foreignKey = $model->belongsTo[$aggregate['model']]['foreignKey'];
             $foreignId = $model->data[$model->alias][$foreignKey]; 
             $this->__updateCache($model, $aggregate, $foreignKey, $foreignId); 
+            $oldForeignId = $this->foreignTableIDs[$aggregate['model']];
+            if( !$created && $foreignId != $oldForeignId ) {
+                $this->__updateCache($model, $aggregate, $foreignKey, $oldForeignId);
+            }            
         } 
     } 
 


### PR DESCRIPTION
On update of a model, if the foreignId changed (IE, comment moved to different post) the aggregateCache would be updated on the new foreign model, but the cache would remain untouched on the old model, leaving the cache out of sync. This update looks for changes in the foreignId and if detected calls __updateCache on both old and new models, keeping everything in sync.
