### PR TITLE
check that the associated record exists before saving

### DIFF
--- a/Model/Behavior/AggregateCacheBehavior.php
+++ b/Model/Behavior/AggregateCacheBehavior.php
@@ -90,7 +90,9 @@ class AggregateCacheBehavior extends ModelBehavior {
                 }
             } 
             $assocModel->id = $foreignId; 
-            $assocModel->save($newValues, false, array_keys($newValues)); 
+            if ($assocModel->exists()) {
+                $assocModel->save($newValues, false, array_keys($newValues)); 
+            }
         } 
     } 
 


### PR DESCRIPTION
The behavior doesn't check that the associated model exists before calling save(). This can, in certain circumstances, cause the behavior to create errant records in the database which is likely not desirable. 

The proposed change simply checks that the associated model exists before issuing the save. If the model does not exist then it silently doesn't do anything (whether it should throw an error is up for debate). 
